### PR TITLE
 Improves and extends the smoke test suite for the Rolnopol application

### DIFF
--- a/TEST_PLAN.md
+++ b/TEST_PLAN.md
@@ -13,9 +13,7 @@ Testing strategy for Rolnopol agricultural management system based on http://loc
 ### 1. Smoke Tests ✅
 
 - [x] Homepage loads with title "Rolnopol" `@smoke` `@critical`
-- [x] Login page loads and form elements visible `@smoke` `@navigation`
-- [x] Register page loads and form elements visible `@smoke` `@navigation`
-- [ ] Docs and marketplace pages accessible `@smoke` `@navigation`
+- [ ] Key pages accessible (login, register, docs, marketplace) `@smoke` `@navigation`
 - [ ] API health check responds `@smoke` `@api`
 
 ### 2. Authentication

--- a/tests/main.smoke.spec.ts
+++ b/tests/main.smoke.spec.ts
@@ -11,7 +11,7 @@ test(
 
 test(
   "should load login page successfully",
-  { tag: ["@smoke", "@auth"] },
+  { tag: ["@smoke", "@navigation", "@auth"] },
   async ({ page }) => {
     const expectedSubtitle = "User Login & Account Access";
 

--- a/tests/main.smoke.spec.ts
+++ b/tests/main.smoke.spec.ts
@@ -6,23 +6,31 @@ test(
   async ({ page }) => {
     await page.goto("");
     await expect(page).toHaveTitle("Rolnopol");
-  }
+  },
 );
 
 test(
   "should load login page successfully",
   { tag: ["@smoke", "@auth"] },
   async ({ page }) => {
+    const expectedSubtitle = "User Login & Account Access";
+
     await page.goto("/login.html");
-    await expect(page.locator("body")).toBeVisible();
-  }
+    await expect(page.getByTestId("login-subtitle")).toHaveText(
+      expectedSubtitle,
+    );
+  },
 );
 
 test(
   "should load register page successfully",
   { tag: ["@smoke", "@auth"] },
   async ({ page }) => {
+    const expectedSubtitle = "Create Your User Account";
+
     await page.goto("/register.html");
-    await expect(page.locator("body")).toBeVisible();
-  }
+    await expect(page.getByTestId("register-subtitle")).toHaveText(
+      expectedSubtitle,
+    );
+  },
 );

--- a/tests/main.smoke.spec.ts
+++ b/tests/main.smoke.spec.ts
@@ -34,3 +34,25 @@ test(
     );
   },
 );
+
+test(
+  "should load swagger page successfully",
+  { tag: ["@smoke", "@api"] },
+  async ({ page }) => {
+    await page.goto("/swagger.html");
+    await expect(page).toHaveTitle("Rolnopol - Swagger");
+  },
+);
+
+test(
+  "should load docs page successfully",
+  { tag: ["@smoke", "@docs"] },
+  async ({ page }) => {
+    const expectedSubtitle = "Rolnopol System Guide & API Reference";
+
+    await page.goto("/docs.html");
+    await expect(page.getByTestId("docs-header-title-col")).toContainText(
+      expectedSubtitle,
+    );
+  },
+);


### PR DESCRIPTION
## Changes

### Tests (`tests/main.smoke.spec.ts`)
- Replaced generic `body` visibility assertions with specific `data-testid` locators and text assertions on the login and register pages
- Added smoke test for `/swagger.html` — asserts correct page title (`"Rolnopol - Swagger"`) — tagged `@smoke @api`
- Added smoke test for `/docs.html` — asserts subtitle text via `data-testid="docs-header-title-col"` — tagged `@smoke @docs`

### Test Plan (`TEST_PLAN.md`)
- Updated smoke test checklist to reflect current implementation state