### PR TITLE
Add main branch trigger to Playwright workflow

### DIFF
--- a/.github/workflows/plawright-e2e-tests.yml
+++ b/.github/workflows/plawright-e2e-tests.yml
@@ -2,6 +2,9 @@ name: Playwright Tests
 
 on:
   pull_request: 
+  push:
+    branches:
+      - main
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Description
Add a push trigger for the main branch to the Playwright E2E test workflow. This ensures tests run automatically when code is merged to main, providing continuous validation of the build status.

## Changes
- Added `push` trigger with `main` branch filter to workflow

## Testing
The workflow will now execute on:
- Pull requests (existing behavior)
- Pushes to main (new behavior)